### PR TITLE
new: add ApeDAO OG Apes NFT collection

### DIFF
--- a/shimmer/nfts/ApeDAO-OG_Apes-0x635193a080f8325c426bf35acefe5548fd1dd931972bc3d6cec5112889afccce.json
+++ b/shimmer/nfts/ApeDAO-OG_Apes-0x635193a080f8325c426bf35acefe5548fd1dd931972bc3d6cec5112889afccce.json
@@ -1,0 +1,12 @@
+{
+  "standard": "IRC27",
+  "version": "v1.0",
+  "type": "image/png",
+  "uri": "ipfs://bafybeiavlpfr33ny3uvn5chkhxhpv3cu5lgtpgpop6ma25cqxiqucnvbaa",
+  "name": "OG Apes",
+  "description": "A collection of 1074 randomly-generated OG Ape NFTs that make you an ApeDAO participant.",
+  "issuerName": "ApeDAO",
+  "royalties": {
+    "smr1qzh0kkkutk38ewdddr4vg3c7sl3l63yfctwhyyvm80cdjryptm86kdksmxu": 0.1
+  }
+}


### PR DESCRIPTION
### Description

"A collection of 1074 randomly-generated OG Ape NFTs that make you an ApeDAO participant."

### Type
- [ ] Native Token
- [ ] Sole NFT
- [X] Collection NFT

Link to foundry/NFT in explorer: `https://explorer.shimmer.network/shimmer/addr/smr1zp34ryaqsruryhzzd0e44nh724y068wexxtjhs7kemz3z2yf4lxvux47c36`

### Social media:
- Twitter: https://twitter.com/iotapes
- Discord: https://discord.gg/WDxt6xZDDh
- Medium: https://iotapes.medium.com/

### Checklist
- [X] IRC27/30 data is in the immutable metadata field of the foundry/NFT output
- [x] Public key can verify ownership over the creation of the foundry/NFT output